### PR TITLE
TSW-196815: Changing monitor installation URL to use cloudsmith instead of azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This script enables automating the installation and registration of Anyware Moni
 ## Example on how to use the script
 
 ```
-PS C:> .\deploy_monitor.ps1 -config_file file.json -monitor_hostname 'hostname.domain.local' -manager_url <https://cas-staging.teradici.com>
+powershell.exe -noexit "./deploy_monitor.ps1 Invoke-Expression; deploy -config_file file.json -manager_url https://cas.teradici.com -monitor_machine_name hostname.domain.local;exit"
 ```
 
 ## Example on how to use the script with "-ignore_cert"

--- a/deploy_monitor.ps1
+++ b/deploy_monitor.ps1
@@ -46,6 +46,8 @@ new-module -name deploy_monitor -scriptblock {
             [string]$manager_url,
             [Parameter()]
             [switch]$ignore_cert = $false
+            [Parameter()]
+            [switch]$channel = "stable"
         )
 
         #Requires -RunAsAdministrator
@@ -183,7 +185,18 @@ new-module -name deploy_monitor -scriptblock {
 
         Function InstallMonitor([string] $monitorToken) {
             Write-Host "--> Starting monitor installation script."
-            $monitorSetupUrl = "https://anyware.blob.core.windows.net/awm-monitor/nightly/latest/awm_monitor_install.ps1"
+            $channelUrls = @{
+                "stable" = "https://dl.teradici.com/EwX7bPdudUUD6bsr/anyware-manager/raw/names/anyware-monitor-ps1/versions/latest/anyware-monitor.ps1"
+                "beta"   = "https://dl.teradici.com/EwX7bPdudUUD6bsr/anyware-manager-beta/raw/names/anyware-monitor-ps1/versions/latest/anyware-monitor.ps1"
+                "dev"    = "https://dl.teradici.com/EwX7bPdudUUD6bsr/anyware-manager-dev/raw/names/anyware-monitor-ps1/versions/latest/anyware-monitor.ps1"
+            }
+
+            if ($channelUrls.ContainsKey($channel)) {
+                $monitorSetupUrl = $channelUrls[$channel]
+            } else {
+                Write-Host "ERROR: Invalid channel specified."
+                exit
+            }
 
             $params = @{
                 manager_uri = $manager_url

--- a/deploy_monitor.ps1
+++ b/deploy_monitor.ps1
@@ -45,7 +45,7 @@ new-module -name deploy_monitor -scriptblock {
             [Parameter(Mandatory = $true)]
             [string]$manager_url,
             [Parameter()]
-            [switch]$ignore_cert = $false
+            [switch]$ignore_cert = $false,
             [Parameter()]
             [switch]$channel = "stable"
         )

--- a/deploy_monitor.ps1
+++ b/deploy_monitor.ps1
@@ -193,12 +193,7 @@ new-module -name deploy_monitor -scriptblock {
                 "dev"    = "https://dl.teradici.com/$cloudsmithToken/anyware-manager-dev/raw/names/anyware-monitor-ps1/versions/latest/anyware-monitor.ps1"
             }
 
-            if ($channelUrls.ContainsKey($channel)) {
-                $monitorSetupUrl = $channelUrls[$channel]
-            } else {
-                Write-Host "ERROR: Invalid channel specified."
-                exit
-            }
+            $monitorSetupUrl = $channelUrls[$channel]
 
             $params = @{
                 manager_uri = $manager_url

--- a/deploy_monitor.ps1
+++ b/deploy_monitor.ps1
@@ -47,6 +47,7 @@ new-module -name deploy_monitor -scriptblock {
             [Parameter()]
             [switch]$ignore_cert = $false,
             [Parameter()]
+            [ValidateSet("stable", "beta", "dev")]
             [string]$channel = "stable"
         )
 
@@ -66,15 +67,15 @@ new-module -name deploy_monitor -scriptblock {
                 "###############################################################################"
 
                 add-type @"
-	using System.Net;
-	using System.Security.Cryptography.X509Certificates;
-	public class TrustAllMonitorCertsPolicy : ICertificatePolicy {
-		public bool CheckValidationResult(
-			ServicePoint srvPoint, X509Certificate certificate,
-			WebRequest request, int certificateProblem) {
-			return true;
-		}
-	}
+    using System.Net;
+    using System.Security.Cryptography.X509Certificates;
+    public class TrustAllMonitorCertsPolicy : ICertificatePolicy {
+        public bool CheckValidationResult(
+            ServicePoint srvPoint, X509Certificate certificate,
+            WebRequest request, int certificateProblem) {
+            return true;
+        }
+    }
 "@
                 [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllMonitorCertsPolicy
 
@@ -184,11 +185,12 @@ new-module -name deploy_monitor -scriptblock {
         }
 
         Function InstallMonitor([string] $monitorToken) {
+            $cloudsmithToken = "EwX7bPdudUUD6bsr"
             Write-Host "--> Starting monitor installation script."
             $channelUrls = @{
-                "stable" = "https://dl.teradici.com/EwX7bPdudUUD6bsr/anyware-manager/raw/names/anyware-monitor-ps1/versions/latest/anyware-monitor.ps1"
-                "beta"   = "https://dl.teradici.com/EwX7bPdudUUD6bsr/anyware-manager-beta/raw/names/anyware-monitor-ps1/versions/latest/anyware-monitor.ps1"
-                "dev"    = "https://dl.teradici.com/EwX7bPdudUUD6bsr/anyware-manager-dev/raw/names/anyware-monitor-ps1/versions/latest/anyware-monitor.ps1"
+                "stable" = "https://dl.teradici.com/$cloudsmithToken/anyware-manager/raw/names/anyware-monitor-ps1/versions/latest/anyware-monitor.ps1"
+                "beta"   = "https://dl.teradici.com/$cloudsmithToken/anyware-manager-beta/raw/names/anyware-monitor-ps1/versions/latest/anyware-monitor.ps1"
+                "dev"    = "https://dl.teradici.com/$cloudsmithToken/anyware-manager-dev/raw/names/anyware-monitor-ps1/versions/latest/anyware-monitor.ps1"
             }
 
             if ($channelUrls.ContainsKey($channel)) {
@@ -201,6 +203,8 @@ new-module -name deploy_monitor -scriptblock {
             $params = @{
                 manager_uri = $manager_url
                 token       = $monitorToken
+                download_token = $cloudsmithToken
+                channel     = $channel
             }
             if ($ignore_cert) {
                 $params.Add("ignore_cert", 1)

--- a/deploy_monitor.ps1
+++ b/deploy_monitor.ps1
@@ -47,7 +47,7 @@ new-module -name deploy_monitor -scriptblock {
             [Parameter()]
             [switch]$ignore_cert = $false,
             [Parameter()]
-            [switch]$channel = "stable"
+            [string]$channel = "stable"
         )
 
         #Requires -RunAsAdministrator


### PR DESCRIPTION
This commit changes the download URL from Cloudsmith to Azure, additionally, it also adds the channel parameter so the monitor version that will be installed can change based on it.

Screenshot of the installation process:
![image](https://github.com/HPInc/Anyware-Monitor-Deploy/assets/117947397/b9334100-efb7-425e-9f54-e26743e4ceae)

Screenshot of the machine as Healthy:
![image](https://github.com/HPInc/Anyware-Monitor-Deploy/assets/117947397/be874455-756b-4911-932f-08aeec205674)
